### PR TITLE
IDE 코드 실행 API 주소를 별도 ideconfig 파일로 분리

### DIFF
--- a/src/components/ide/IDE.jsx
+++ b/src/components/ide/IDE.jsx
@@ -3,6 +3,8 @@ import { Link, useNavigate, useLocation, useParams } from 'react-router-dom';
 import Editor from '@monaco-editor/react';
 import './IDE.css';
 //npm install @monaco-editor/react
+import ideConfig from '../../ideconfig';
+
 
 // ResizeObserver 패치 함수 정의
 const applyResizeObserverFix = () => {
@@ -596,8 +598,7 @@ const IDE = () => {
         return map;
     };
 
-    // API 엔드포인트 URL 설정 (스웨거 API로 변경)
-    const API_URL = 'http://13.209.72.114:8080/api/code/run';
+    const apiUrl = `${ideConfig.API_BASE_URL}/code/run`;
 
     // 스웨거 API에 맞게 언어 매핑 함수
     const mapLanguageToAPI = (langId) => {
@@ -630,10 +631,6 @@ const IDE = () => {
 
             console.log('API 요청 데이터:', JSON.stringify(requestBody));
 
-            // CORS 우회를 위한 프록시 서버 사용 (개발 환경에서)
-            const apiUrl = process.env.NODE_ENV === 'development'
-                ? '/api/code/run'  // 개발 환경에서는 프록시 사용
-                : 'http://13.209.72.114:8080/api/code/run'; // 프로덕션 환경에서는 직접 호출
 
             // API 호출
             const response = await fetch(apiUrl, {

--- a/src/ideconfig.js
+++ b/src/ideconfig.js
@@ -1,0 +1,12 @@
+const ideconfig = {
+    // 기존 설정
+    SOME_EXISTING_CONFIG: 'value',
+
+    // ✅ API 주소 설정 추가
+    API_BASE_URL:
+        process.env.NODE_ENV === 'development'
+            ? '/api'
+            : 'http://13.209.72.114:8080/api'
+};
+
+export default ideconfig;


### PR DESCRIPTION
## 변경 내용

- IDE 컴포넌트 내 하드코딩된 코드 실행 API 주소 제거
- `ideconfig.js` 파일을 새로 생성하여 API_BASE_URL을 전역 관리
- 환경에 따라 API 주소를 분리하여 유지보수 및 확장성 향상

## 주요 수정 사항

- `IDE.jsx` 상단에 `ideConfig` import 추가
- 기존 하드코딩된 `fetch` API URL 제거
- `ideConfig.API_BASE_URL` 기반으로 동적으로 API URL 구성
- 향후 다른 API (`SAVE`, `LOAD`, `VISUALIZE` 등) 확장 가능하도록 설계

