### PR TITLE
실행 API 주소 config.js에서 일괄 관리하도록 변경

### DIFF
--- a/src/components/ide/IDE.jsx
+++ b/src/components/ide/IDE.jsx
@@ -614,7 +614,7 @@ const IDE = () => {
         return map;
     };
 
-    const apiUrl = `${config.API_BASE_URL}/api/code/run`;
+    const apiUrl = config.API_ENDPOINTS.RUN_CODE;
 
     // 스웨거 API에 맞게 언어 매핑 함수
     const mapLanguageToAPI = (langId) => {

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,16 @@
-// 프록시 없이 직접 API 서버 주소 사용
+// config.js
+const API_BASE_URL = 'https://api.zivorp.com';
+
+const API_ENDPOINTS = {
+    LOGIN: `${API_BASE_URL}/api/auth/login`,
+    SIGNUP: `${API_BASE_URL}/api/auth/signup`,
+    RUN_CODE: `${API_BASE_URL}/api/code/run`,
+    // 필요시 다른 엔드포인트도 추가
+};
+
 const config = {
-    API_BASE_URL: 'https://api.zivorp.com',  // ✅ 항상 고정된 주소 사용
+    API_BASE_URL,
+    API_ENDPOINTS
 };
 
 export default config;


### PR DESCRIPTION
기존 IDE 컴포넌트에서 코드 실행 API(`/api/code/run`)를 직접 문자열로 사용하고 있었던 부분을 config.js의 API_ENDPOINTS 객체로 분리

변경 사항:

- `config.API_ENDPOINTS.RUN_CODE`를 사용하여 API 주소 하드코딩 제거