### PR TITLE
코드방송 IDE 라이브러리 연결 및 UI 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ import ScrollToTop from "./components/common/ScrollToTop";
 import CommunityWrite from "./components/community/CommunityWrite";
 import VisualizationModal from "./components/ide/VisualizationModal";
 import PostDetail from "./components/community/PostDetail"; // ✅ 게시글 상세 컴포넌트 추가
+import CodecastLive from "./components/codecast/codecastlive/CodecastLive";
 
 function AppContent() {
     const location = useLocation();
@@ -77,6 +78,7 @@ function AppContent() {
                 <Route path="/community/post/:id" element={<PostDetail />} /> {/* ✅ 상세 페이지 라우팅 추가 */}
                 <Route path="/broadcast" element={<Codecast />} />
                 <Route path="/startbroadcast" element={<StartCodecast />} />
+                <Route path="/broadcast/live" element={<CodecastLive />} />
                 <Route path="/mypage" element={<MyPageLayout nickname={nickname} />}>
                     <Route index element={<Mypage nickname={nickname} />} />
                     <Route path="project" element={<MyProject />} />

--- a/src/components/codecast/codecastlive/CodeEditor.jsx
+++ b/src/components/codecast/codecastlive/CodeEditor.jsx
@@ -1,42 +1,29 @@
-import React from 'react';
-import './CodeEditor.css';
+import React, {useEffect, useState} from 'react';
+import Editor from '@monaco-editor/react';
 import { FaPlay } from 'react-icons/fa';
+import './CodeEditor.css';
 
-const currentUser = {
-    name: '김코딩',
-    role: 'host',
-    code: `# 버블 정렬 구현
-def bubble_sort(arr):
-    n = len(arr)
+const CodeEditor = ({ currentUser }) => {
+    const [code, setCode] = useState(currentUser.code);
 
-    for i in range(n):
-        for j in range(0, n - i - 1):
-            if arr[j] > arr[j + 1]:
-                # 두 요소 교환
-                arr[j], arr[j + 1] = arr[j + 1], arr[j]
+    // ✅ currentUser가 바뀔 때마다 코드 상태를 새로 설정
+    useEffect(() => {
+        setCode(currentUser.code);
+    }, [currentUser]);
 
-    return arr
-
-# 예제 배열
-array = [64, 34, 25, 12, 22, 11, 90]
-print("정렬 전:", array)
-print("정렬 후:", bubble_sort(array.copy()))`
-};
-
-const getIcon = (role) => {
-    switch (role) {
-        case 'host':
-            return '👑';
-        case 'editing':
-            return '✍️';
-        default:
-            return '';
-    }
-};
-
-const CodeEditor = () => {
     const handleRun = () => {
         alert("코드 실행 기능은 아직 미구현입니다.");
+    };
+
+    const getIcon = (role) => {
+        switch (role) {
+            case 'host':
+                return '👑';
+            case 'editing':
+                return '✍️';
+            default:
+                return '';
+        }
     };
 
     return (
@@ -46,12 +33,22 @@ const CodeEditor = () => {
                     {getIcon(currentUser.role)} {currentUser.name}
                 </div>
                 <button className="run-button" onClick={handleRun}>
-                    <FaPlay/> 실행
+                    <FaPlay /> 실행
                 </button>
             </div>
-            <pre className="code-block">
-                <code>{currentUser.code}</code>
-            </pre>
+
+            <Editor
+                height="calc(100vh - 160px)" // 헤더와 버튼 고려
+                defaultLanguage="python"
+                theme="vs-dark"
+                value={code}
+                onChange={(newValue) => setCode(newValue)}
+                options={{
+                    fontSize: 14,
+                    minimap: { enabled: false },
+                    padding: { top: 10 },
+                }}
+            />
         </section>
     );
 };

--- a/src/components/codecast/codecastlive/CodePreviewList.css
+++ b/src/components/codecast/codecastlive/CodePreviewList.css
@@ -42,14 +42,10 @@
     font-size: 16px;
 }
 
-.preview-language {
-    font-size: 12px;
-    color: #aaa;
-    margin-bottom: 8px;
-}
-
 .preview-code {
     padding: 12px;
     white-space: pre-wrap;
     line-height: 1.5;
+    max-height: calc(1.4em * 5); /* 4줄 기준 */
+    overflow: hidden;
 }

--- a/src/components/codecast/codecastlive/CodePreviewList.jsx
+++ b/src/components/codecast/codecastlive/CodePreviewList.jsx
@@ -1,37 +1,20 @@
 import React from 'react';
 import './CodePreviewList.css';
 
-const previews = [
-    {
-        name: '김코딩',
-        // language: 'Python',
-        code: `# 버블 정렬 구현\ndef bubble_sort(arr):\n    n = len(arr)\n`,
-        isHost: true
-    },
-    {
-        name: '이알고',
-        // language: 'JavaScript',
-        code: `// 퀵 정렬 구현\nfunction quickSort(arr) {\n    if (arr.length <= 1) {\n        return arr;`,
-        isHost: false
-    },
-    {
-        name: '박개발',
-        // language: 'JavaScript',
-        code: `// 병합 정렬 구현\nfunction mergeSort(arr) {\n    if (arr.length <= 1) {\n        return arr;`,
-        isHost: false
-    }
-];
-
-const CodePreviewList = () => {
+const CodePreviewList = ({ participants, onSelect }) => {
     return (
         <section className="code-preview-list">
-            {previews.map((p, idx) => (
-                <div key={idx} className="code-preview-card">
+            {participants.map((p, idx) => (
+                <div
+                    key={idx}
+                    className="code-preview-card"
+                    onClick={() => onSelect(p)}
+                    style={{ cursor: 'pointer' }}
+                >
                     <div className="card-header">
                         <span className="card-name">{p.name}</span>
-                        {p.isHost && <span className="card-role">👑</span>}
+                        {p.role === 'host' && <span className="card-role">👑</span>}
                     </div>
-                    {/*<div className="preview-language">{p.language}</div>*/}
                     <pre className="preview-code">{p.code}</pre>
                 </div>
             ))}

--- a/src/components/codecast/codecastlive/CodecastHeader.css
+++ b/src/components/codecast/codecastlive/CodecastHeader.css
@@ -1,4 +1,4 @@
-.broadcast-header {
+.broadcastlive-header {
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/src/components/codecast/codecastlive/CodecastHeader.jsx
+++ b/src/components/codecast/codecastlive/CodecastHeader.jsx
@@ -8,7 +8,7 @@ const CodecastHeader = () => {
     };
 
     return (
-        <header className="broadcast-header">
+        <header className="broadcastlive-header">
             <div className="header-left">
                 <h1 className="broadcast-title">정렬 알고리즘 라이브 코딩</h1>
             </div>

--- a/src/components/codecast/codecastlive/CodecastLive.css
+++ b/src/components/codecast/codecastlive/CodecastLive.css
@@ -4,6 +4,7 @@
     height: 100vh;
     background-color: #111;
     color: white;
+    padding-top: 70px;
 }
 
 .main-section {

--- a/src/components/codecast/codecastlive/CodecastLive.jsx
+++ b/src/components/codecast/codecastlive/CodecastLive.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './CodecastLive.css';
 
 import Header from './CodecastHeader';
@@ -6,17 +6,58 @@ import Sidebar from './CodecastSidebar';
 import CodeEditor from './CodeEditor';
 import CodePreviewList from './CodePreviewList';
 
-const CodeBroadcastPage = () => {
+const participants = [
+    {
+        name: '김코딩',
+        code: `# 버블 정렬 구현
+def bubble_sort(arr):
+    n = len(arr)
+
+    for i in range(n):
+        for j in range(0, n - i - 1):
+            if arr[j] > arr[j + 1]:
+                # 두 요소 교환
+                arr[j], arr[j + 1] = arr[j + 1], arr[j]
+
+    return arr
+
+# 예제 배열
+array = [64, 34, 25, 12, 22, 11, 90]
+print("정렬 전:", array)
+print("정렬 후:", bubble_sort(array.copy()))`,
+        role: 'host'
+    },
+    {
+        name: '이알고',
+        code: `// 퀵 정렬 구현\nfunction quickSort(arr) {\n    if (arr.length <= 1) {\n        return arr;`,
+        role: 'editing'
+    },
+    {
+        name: '박개발',
+        code: `// 병합 정렬 구현\nfunction mergeSort(arr) {\n    if (arr.length <= 1) {\n        return arr;`,
+        role: 'editing'
+    }
+];
+
+const CodecastLive = () => {
+    const [currentUser, setCurrentUser] = useState(participants[0]);
+
     return (
         <div className="broadcast-wrapper">
             <Header />
             <div className="main-section">
-                <Sidebar />
-                <CodeEditor />
+                <Sidebar
+                    participants={participants}
+                    currentUser={currentUser}
+                />
+                <CodeEditor currentUser={currentUser} />
             </div>
-            <CodePreviewList />
+            <CodePreviewList
+                participants={participants}
+                onSelect={(user) => setCurrentUser(user)}
+            />
         </div>
     );
 };
 
-export default CodeBroadcastPage;
+export default CodecastLive;

--- a/src/components/codecast/codecastlive/CodecastSidebar.css
+++ b/src/components/codecast/codecastlive/CodecastSidebar.css
@@ -9,6 +9,7 @@
 .sidebar-title {
     font-size: 16px;
     margin-bottom: 12px;
+    color: white;
 }
 
 .participant-list {
@@ -39,4 +40,10 @@
 
 .participant-icon.gray {
     color: #777;
+}
+
+.participant-item.active-user {
+    background-color: #2a2a2a;
+    /*border-left: 4px solid #6a0dad;*/
+    font-weight: bold;
 }

--- a/src/components/codecast/codecastlive/CodecastSidebar.jsx
+++ b/src/components/codecast/codecastlive/CodecastSidebar.jsx
@@ -2,14 +2,6 @@ import React from 'react';
 import './CodecastSidebar.css';
 import { FaCrown, FaPenFancy, FaCircle } from 'react-icons/fa';
 
-const participants = [
-    { name: '김코딩', role: 'host' },
-    { name: '이알고', role: 'editing' },
-    { name: '박개발', role: 'editing' },
-    { name: '최자료', role: 'viewer' },
-    { name: '정해시', role: 'viewer' }
-];
-
 const getIcon = (role) => {
     switch (role) {
         case 'host':
@@ -21,13 +13,16 @@ const getIcon = (role) => {
     }
 };
 
-const CodecastSidebar = () => {
+const CodecastSidebar = ({ participants, currentUser }) => {
     return (
         <aside className="sidebar">
             <h2 className="sidebar-title">참여자 ({participants.length})</h2>
             <ul className="participant-list">
                 {participants.map((p, idx) => (
-                    <li key={idx} className="participant-item">
+                    <li
+                        key={idx}
+                        className={`participant-item ${p.name === currentUser.name ? 'active-user' : ''}`}
+                    >
                         {getIcon(p.role)}
                         <span>{p.name}</span>
                     </li>


### PR DESCRIPTION
## ✨ 주요 변경 사항
### CodePreviewList
- 카드 클릭 시 onSelect 이벤트 발생
- 클릭한 참가자의 코드가 중앙 IDE에 반영됨
- 미리보기 카드의 코드 표시 줄 수 제한 (max-height 설정)
### CodeEditor
- VS Code 기반의 Monaco Editor 적용
- currentUser가 바뀌면 코드 자동 반영 (useEffect로 처리)
- 역할 아이콘(👑/✍️) 표시 문제 해결 및 스타일 정리
### CodecastSidebar
- participants 정보를 props로 받아 사용하도록 구조 통일
- 더 이상 자체 participants 배열 사용하지 않음
- 현재 보고 있는 사용자(currentUser) 강조 스타일 추가
### CodecastLive
- participants 및 currentUser를 중앙에서 관리
- 모든 서브 컴포넌트에 props로 전달 (단일 데이터 소스 유지)