### PR TITLE
커뮤니티 게시글 목록 조회, 게시글 등록 API 연결

### DIFF
--- a/src/components/community/Community.css
+++ b/src/components/community/Community.css
@@ -379,7 +379,7 @@ html {
     border-radius: 0;
     padding: 12px 0;
     border-bottom: 1px solid #eaeaea;
-
+    min-width: 720px;
 }
 
 .post-card:first-child {

--- a/src/components/community/Community.jsx
+++ b/src/components/community/Community.jsx
@@ -1,104 +1,91 @@
-import React from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import {useNavigate} from "react-router-dom";
 import "./Community.css";
+
+const API_BASE = "http://52.79.145.160:8080";
 
 export default function Community() {
     const navigate = useNavigate();
     const tabs = ["전체", "미해결", "해결됨"];
     const filters = ["최신순", "정확도순", "답변많은순", "좋아요순"];
 
-    const posts = [
-        {
-            status: "해결됨",
-            title: "버블 정렬 시각화 프로젝트 공유합니다",
-            summary: "버블 정렬 알고리즘을 시각적으로 이해하기 쉽게 구현해보았습니다. 피드백 부탁드려요!",
-            tags: ["알고리즘", "정렬", "시각화"],
-            author: "김코딩",
-            date: "2023. 5. 15",
-            likes: 24,
-            comments: 8
-        },
-        {
-            status: "해결됨",
-            title: "그래프 탐색 알고리즘 비교: BFS vs DFS",
-            summary: "그래프 탐색 알고리즘의 차이점을 비교하고 어떤 상황에서 더 적합한지 정리했습니다.",
-            tags: ["그래프", "BFS", "DFS"],
-            author: "이알고",
-            date: "2023. 5. 17",
-            likes: 32,
-            comments: 12
-        },
-        {
-            status: "해결됨",
-            title: "동적 프로그래밍 문제 해결 가이드",
-            summary: "DP 문제를 효율적으로 푸는 전략과 예제를 모아 정리해봤습니다.",
-            tags: ["DP", "문제풀이", "코딩테스트"],
-            author: "박코딩",
-            date: "2023. 5. 18",
-            likes: 40,
-            comments: 15
-        },
-        {
-            status: "해결됨",
-            title: "수강 중 문의드립니다!",
-            summary: "안녕하세요! 수업 강의 잘 듣고 있습니다! 궁금한 게 있어서 문의 남깁니다! numeric_only=True는 이번에 시험환경이 엄...",
-            tags: ["python", "머신러닝", "빅데이터", "pandas", "빅데이터분석기사"],
-            author: "lettig0555",
-            date: "2시간 전",
-            likes: 6,
-            comments: 13
-        },
-        {
-            status: "해결됨",
-            title: "rmse 값 구하기",
-            summary: "랜덤포레스트 후 rmse 값을 구할 때 이렇게 구해도 상관없을까요?? from sklearn.ensemble import RandomForest...",
-            tags: ["python", "머신러닝", "빅데이터", "pandas", "빅데이터분석기사"],
-            author: "민우",
-            date: "6분 전",
-            likes: 0,
-            comments: 2
-        },
-        {
-            status: "미해결",
-            title: "2025년 1회 구조체와 연결리스트 문제누락",
-            summary: "5페이지 구조체와 연결리스트 해설 누락된 것 같습니다.",
-            tags: ["python", "java", "c", "정보처리기사"],
-            author: "hyungjun jo",
-            date: "7시간 전",
-            likes: 0,
-            comments: 3
-        },
-        {
-            status: "해결됨",
-            title: "작업형2, 작업형3 pd.get_dummies 시 drop_first 유무",
-            summary: "작업형2 할때는 pd.get_dummies(df) 할때 drop_first가 들어가 있지 않았는데 작업형3 강의에서는 다중공선성 피해...",
-            tags: ["python", "머신러닝", "빅데이터", "pandas", "빅데이터분석기사"],
-            author: "섭식",
-            date: "9시간 전",
-            likes: 6,
-            comments: 3
-        },
-        {
-            status: "미해결",
-            title: "궁금한게 있습니다!",
-            summary: "학습 관련 질문을 남겨주세요. 상세히 작성하면 더 좋아요! 질문글과 관련된 영상 위치를 알려주면 더 빠르게 답변드릴 수 있어요!",
-            tags: ["python", "머신러닝", "빅데이터", "pandas", "빅데이터분석기사"],
-            author: "eovnffppa",
-            date: "9시간 전",
-            likes: 0,
-            comments: 15
-        },
-        {
-            status: "해결됨",
-            title: "안녕하세요 주말코딩님 질문드립니다",
-            summary: "안녕하세요 주말코딩님. 저는 완전 문과 노베이스고 지금은 대기업 하청 전산실 OP로 일하면서 정보처리기사 실기 시험을...",
-            tags: ["python", "정보처리기사"],
-            author: "김재호",
-            date: "10시간 전",
-            likes: 0,
-            comments: 10
-        }
-    ];
+    // ✅ 서버 데이터 상태
+    const [posts, setPosts] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        let ignore = false;
+        const controller = new AbortController();
+
+        (async () => {
+            try {
+                setLoading(true);
+                setError("");
+
+                const token = localStorage.getItem("token");
+                if (!token) {
+                    // 🚨 비회원 접근 차단
+                    alert("로그인이 필요합니다.");
+                    navigate("/");
+                    return;
+                }
+
+                const res = await fetch(`${API_BASE}/api/posts`, {
+                    method: "GET",
+                    headers: {
+                        Accept: "application/json",
+                        Authorization: `Bearer ${token}`,
+                    },
+                    signal: controller.signal,
+                    credentials: "include",
+                });
+
+                if (!res.ok) {
+                    const text = await res.text();
+                    throw new Error(text || `목록 조회 실패 (${res.status})`);
+                }
+
+                const data = await res.json(); // ← 배열 형태 가정
+                if (ignore) return;
+
+                // ✅ createdAt(또는 id) 기준으로 최신 글이 먼저 오도록 정렬
+                const getTime = (x) => (x ? Date.parse(x) || 0 : 0);
+                const sorted = (Array.isArray(data) ? data : [])
+                    .slice()
+                    .sort((a, b) => {
+                        const diff = getTime(b.createdAt) - getTime(a.createdAt);
+                        if (diff !== 0) return diff;
+                        // createdAt이 같거나 비어있으면 id 내림차순으로 보정
+                        return (b.id ?? 0) - (a.id ?? 0);
+                    });
+
+                // 🔄 정렬된 목록을 UI 필드로 매핑
+                const mapped = sorted.map((p) => ({
+                    id: p.id,
+                    status: p.status || "",
+                    title: p.title,
+                    summary: (p.content || "").replace(/<[^>]+>/g, "").slice(0, 120),
+                    tags: p.tags || [],
+                    author: p.writer || "익명",
+                    date: p.createdAt ? new Date(p.createdAt).toLocaleString() : "",
+                    likes: p.likeCount ?? 0,
+                    comments: p.commentCount ?? 0,
+                }));
+
+                setPosts(mapped);
+            } catch (e) {
+                if (!ignore) setError(e.message || "알 수 없는 오류");
+            } finally {
+                if (!ignore) setLoading(false);
+            }
+        })();
+
+        return () => {
+            ignore = true;
+            controller.abort();
+        };
+    }, []);
 
     return (
         <div className="community-wrapper">
@@ -155,42 +142,55 @@ export default function Community() {
                         </button>
                     </div>
 
-                    <div className="post-list">
-                        {posts.map((post, i) => (
-                            <div
-                                key={i}
-                                className="post-card"
-                                onClick={() => navigate(`/community/post/${i}`)}
-                                style={{ cursor: "pointer" }}
-                            >
-                                <div className="post-meta">
-                                    <div className="title-row">
-                                        <span className={`badge ${post.status === "해결됨" ? "badge-solved" : ""}`}>
-                                            {post.status}
-                                        </span>
-                                        <h3 className="post-title">{post.title}</h3>
-                                    </div>
-                                    <p className="post-summary">{post.summary}</p>
-                                </div>
-                                <div className="post-tags">
-                                    {post.tags.map((tag, j) => (
-                                        <span key={j} className="tag">{tag}</span>
-                                    ))}
-                                </div>
-                                <div className="post-footer">
-                                    <div className="post-footer-left">
-                                        <span>{post.author}</span>
-                                        <span>{post.date}</span>
-                                    </div>
-                                    <div className="post-footer-right">
-                                        <span>👍 {post.likes}</span>
-                                        <span>💬 {post.comments}</span>
-                                    </div>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
+                    {/* ✅ 로딩/에러/빈 상태 */}
+                    {loading && <div className="post-list"><p>불러오는 중…</p></div>}
+                    {!loading && error && <div className="post-list"><p className="error">{error}</p></div>}
+                    {!loading && !error && posts.length === 0 && (
+                        <div className="post-list"><p>게시글이 없습니다.</p></div>
+                    )}
 
+                    {!loading && !error && posts.length > 0 && (
+                        <div className="post-list">
+                            {posts.map((post) => (
+                                <div
+                                    key={post.id}
+                                    className="post-card"
+                                    onClick={() => navigate(`/community/post/${post.id}`)} // ← id 사용
+                                    style={{ cursor: "pointer" }}
+                                >
+                                    <div className="post-meta">
+                                        <div className="title-row">
+                                            {/* 상태값 없으면 뱃지 숨김 */}
+                                            {post.status ? (
+                                                <span className={`badge ${post.status === "해결됨" ? "badge-solved" : ""}`}>
+                                                    {post.status}
+                                                </span>
+                                            ) : null}
+                                            <h3 className="post-title">{post.title}</h3>
+                                        </div>
+                                        <p className="post-summary">{post.summary}</p>
+                                    </div>
+                                    <div className="post-tags">
+                                        {(post.tags || []).map((tag, j) => (
+                                            <span key={j} className="tag">{tag}</span>
+                                        ))}
+                                    </div>
+                                    <div className="post-footer">
+                                        <div className="post-footer-left">
+                                            <span>{post.author}</span>
+                                            <span>{post.date}</span>
+                                        </div>
+                                        <div className="post-footer-right">
+                                            <span>👍 {post.likes}</span>
+                                            <span>💬 {post.comments}</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+
+                    {/* 기존 페이징 UI는 유지 (서버 페이징 스펙 나오면 연결) */}
                     <div className="pagination-wrapper">
                         <div className="page-numbers">
                             <button className="page-button active">1</button>
@@ -215,26 +215,11 @@ export default function Community() {
                     <div className="popular-posts">
                         <h4>주간 인기글</h4>
                         <ul>
-                            <li>
-                                <div className="post-title">버블 정렬 시각화 프로젝트 공유합니다</div>
-                                <div className="post-author">김코딩</div>
-                            </li>
-                            <li>
-                                <div className="post-title">그래프 탐색 알고리즘 비교: BFS vs DFS</div>
-                                <div className="post-author">이알고</div>
-                            </li>
-                            <li>
-                                <div className="post-title">동적 프로그래밍 문제 해결 가이드</div>
-                                <div className="post-author">박코딩</div>
-                            </li>
-                            <li>
-                                <div className="post-title">백엔드 신입 CS 스터디 3기 모집</div>
-                                <div className="post-author">김지훈</div>
-                            </li>
-                            <li>
-                                <div className="post-title">AI 실전 활용을 위한 4주 집중 스터디, 애사모!</div>
-                                <div className="post-author">Edun</div>
-                            </li>
+                            <li><div className="post-title">버블 정렬 시각화 프로젝트 공유합니다</div><div className="post-author">김코딩</div></li>
+                            <li><div className="post-title">그래프 탐색 알고리즘 비교: BFS vs DFS</div><div className="post-author">이알고</div></li>
+                            <li><div className="post-title">동적 프로그래밍 문제 해결 가이드</div><div className="post-author">박코딩</div></li>
+                            <li><div className="post-title">백엔드 신입 CS 스터디 3기 모집</div><div className="post-author">김지훈</div></li>
+                            <li><div className="post-title">AI 실전 활용을 위한 4주 집중 스터디, 애사모!</div><div className="post-author">Edun</div></li>
                         </ul>
                     </div>
                 </aside>

--- a/src/components/community/CommunityWrite.jsx
+++ b/src/components/community/CommunityWrite.jsx
@@ -1,11 +1,54 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import {
     FaBold, FaItalic, FaStrikethrough, FaLink, FaPalette, FaCode, FaQuoteRight,
     FaImage, FaHeading, FaListUl, FaListOl, FaMinus
 } from "react-icons/fa";
 import "./CommunityWrite.css";
 
+const API_BASE = "http://52.79.145.160:8080";
+
+// ✅ 백엔드 ENUM과 일치하는 허용 태그
+const ALLOWED_TAGS = [
+    "JAVA","C","CPP","JPA","JAVASCRIPT","PYTHON","OOP","BIGDATA","SPRING","TYPESCRIPT","ML"
+];
+
+// ✅ 흔한 표기 → ENUM 매핑(한국어/소문자/동의어 흡수)
+const TAG_SYNONYM = {
+    js: "JAVASCRIPT", javascript: "JAVASCRIPT", 자바스크립트: "JAVASCRIPT",
+    java: "JAVA", 자바: "JAVA",
+    "c++": "CPP", cpp: "CPP", c: "C",
+    typescript: "TYPESCRIPT", ts: "TYPESCRIPT", 타이프스크립트: "TYPESCRIPT",
+    spring: "SPRING",
+    python: "PYTHON", 파이썬: "PYTHON",
+    jpa: "JPA",
+    oop: "OOP", 객체지향: "OOP",
+    bigdata: "BIGDATA", 빅데이터: "BIGDATA",
+    ml: "ML", 머신러닝: "ML",
+};
+
+function normalizeToEnumTag(raw) {
+    if (!raw) return null;
+    const k = raw.replace(/^#/, "").trim();
+    const keyLC = k.toLowerCase();
+    if (TAG_SYNONYM[keyLC]) return TAG_SYNONYM[keyLC]; // 동의어 우선
+    const upper = k.toUpperCase();
+    return ALLOWED_TAGS.includes(upper) ? upper : null;
+}
+
+// 입력 문자열 → ENUM 배열(중복 제거, 최대 10개)
+function parseTagsInput(input) {
+    const list = input
+        .split(/[#,，,\s]+/) // 쉼표/공백/# 구분
+        .map(normalizeToEnumTag)
+        .filter(Boolean);
+    return Array.from(new Set(list)).slice(0, 10);
+}
+
 export default function CommunityWrite() {
+    const navigate = useNavigate();
+    const location = useLocation();
+
     const defaultGuide = `- 학습 관련 질문을 남겨주세요. 상세히 작성하면 더 좋아요!
 - 마크다운, 단축키를 이용해서 편리하게 글을 작성할 수 있어요.
 - 먼저 유사한 질문이 있었는지 검색해보세요.
@@ -14,24 +57,82 @@ export default function CommunityWrite() {
     const [title, setTitle] = useState("");
     const [tags, setTags] = useState("");
     const [content, setContent] = useState(defaultGuide);
+    const [submitting, setSubmitting] = useState(false);
+
+    // 비회원 접근 차단(알림은 로그인 페이지에서 처리)
+    useEffect(() => {
+        const token = localStorage.getItem("token");
+        if (!token) {
+            navigate("/", { replace: true, state: { reason: "auth-required", from: location.pathname } });
+        }
+    }, [navigate, location.pathname]);
 
     const handleFocus = () => {
         if (content === defaultGuide) setContent("");
     };
-
     const handleBlur = () => {
         if (content.trim() === "") setContent(defaultGuide);
     };
 
-    const handleSubmit = () => {
-        if (!title || content === defaultGuide || content.trim() === "") {
+    const handleSubmit = async () => {
+        const token = localStorage.getItem("token");
+        if (!token) {
+            navigate("/login", { replace: true, state: { reason: "auth-required", from: location.pathname } });
+            return;
+        }
+
+        const t = title.trim();
+        const c = content === defaultGuide ? "" : content.trim();
+        if (!t || !c) {
             alert("제목과 내용을 작성해주세요!");
             return;
         }
 
-        console.log("제목:", title);
-        console.log("태그:", tags);
-        console.log("내용:", content);
+        // ✅ 태그 정규화/검증 → ENUM 배열
+        const tagArray = parseTagsInput(tags);
+
+        // 사용자가 뭔가 입력했는데 결과가 0개면 허용값 아님
+        if (tags.trim() && tagArray.length === 0) {
+            alert(`지원하는 태그만 사용할 수 있어요.\n허용값: ${ALLOWED_TAGS.join(", ")}`);
+            return;
+        }
+
+        const payload = tagArray.length > 0
+            ? { title: t, content: c, tags: tagArray }
+            : { title: t, content: c };
+
+        try {
+            setSubmitting(true);
+            const res = await fetch(`${API_BASE}/api/posts`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Accept: "application/json",
+                    Authorization: `Bearer ${token}`,
+                },
+                credentials: "include",
+                body: JSON.stringify(payload),
+            });
+
+            if (res.status === 401 || res.status === 403) {
+                navigate("/login", { replace: true, state: { reason: "auth-required", from: location.pathname } });
+                return;
+            }
+            if (!res.ok) {
+                const ct = res.headers.get("content-type") || "";
+                const msg = ct.includes("application/json") ? (await res.json()).message : await res.text();
+                throw new Error(msg || `등록 실패 (${res.status})`);
+            }
+
+            const created = await res.json().catch(() => null);
+            alert("등록되었습니다.");
+            if (created?.id) navigate(`/community/post/${created.id}`);
+            else navigate("/community");
+        } catch (e) {
+            alert(e.message || "등록 중 오류가 발생했습니다.");
+        } finally {
+            setSubmitting(false);
+        }
     };
 
     return (
@@ -54,7 +155,7 @@ export default function CommunityWrite() {
             <input
                 type="text"
                 className="tag-input"
-                placeholder="태그를 설정하세요 (최대 10개)"
+                placeholder="태그(쉼표/공백/해시 구분, 예: java, oop, 빅데이터)"
                 value={tags}
                 onChange={(e) => setTags(e.target.value)}
             />
@@ -83,8 +184,10 @@ export default function CommunityWrite() {
             />
 
             <div className="write-actions">
-                <button className="cancel-btn">취소</button>
-                <button className="submit-btn" onClick={handleSubmit}>등록</button>
+                <button className="cancel-btn" onClick={() => navigate(-1)}>취소</button>
+                <button className="submit-btn" onClick={handleSubmit} disabled={submitting}>
+                    {submitting ? "등록 중..." : "등록"}
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
## 요약
- 더미 데이터 제거 → 실서버 API로 게시글 목록/작성 연동
- JWT 인증 가드: 비회원 접근 시 알림 및 리다이렉트
- 목록을 최신순(내림차순) 으로 정렬
- 작성 시 태그 입력을 백엔드 ENUM으로 정규화/검증 후 전송

## 변경 사항
### 1) 목록 페이지 (Community.jsx)
- GET /api/posts 호출 (헤더에 Authorization: Bearer <token>)
- 응답을 클라이언트에서 createdAt 기준 내림차순 정렬 (동일 시 id 내림차순 보정)
- UI 매핑: id, title, content(요약), writer, createdAt, likeCount, commentCount, tags
- 요약은 HTML 제거 후 120자 슬라이스
- 날짜는 toLocaleString() 포맷
- 로딩/에러/빈 상태 처리 추가
- 비회원 차단: 토큰 없으면 알림 후 홈(/)로 이동
### 2) 작성 페이지 (CommunityWrite.jsx)
- 비회원 차단: 토큰 없으면 /login으로 이동 (state: { reason: "auth-required" })
- POST /api/posts 호출 (헤더에 Authorization)
- 태그 파싱/정규화/검증
-- 입력 분리: 쉼표/공백/# 구분 → 중복 제거 → 최대 10개
-- 동의어/한글을 백엔드 ENUM으로 매핑
-- 허용값: JAVA, C, CPP, JPA, JAVASCRIPT, PYTHON, OOP, BIGDATA, SPRING, TYPESCRIPT, ML
-- 유효하지 않은 태그만 있을 경우 안내 후 전송 중단
- 등록 성공 시: 생성된 id가 오면 상세로 이동, 없으면 목록으로 이동

## 사용한 엔드포인트
- GET /api/posts — 게시글 전체 목록 조회 (인증 필요)
- POST /api/posts — 게시글 작성 (인증 필요, body: { title, content, tags: string[] })

## 참고사항
- 현재 비회원이 커뮤니티 접근 시 알림 후 홈으로 이동하는데, 알림이 두 번 뜨는 문제가 있음
- 원인 파악 후 수정 예정 