### PR TITLE
Codecast 헤더, 사이드바, 파일 선택, 프리뷰, 채팅창 업데이트

### DIFF
--- a/src/components/codecast/codecastlive/ChatPanel.css
+++ b/src/components/codecast/codecastlive/ChatPanel.css
@@ -1,0 +1,131 @@
+/* 백드롭 */
+.chat-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .2s ease;
+    z-index: 1500;
+}
+.chat-backdrop.show {
+    background: rgba(0,0,0,0.35);
+    opacity: 1;
+    pointer-events: auto;
+}
+
+/* 패널 */
+.chat-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 360px;
+    max-width: calc(100% - 48px);
+    height: 100vh;
+    background: #fff;
+    border-left: 1px solid #e6e6ef;
+    box-shadow: -8px 0 24px rgba(0,0,0,0.08);
+    transform: translateX(100%);
+    transition: transform .22s ease;
+    z-index: 1600;
+
+    display: flex;
+    flex-direction: column;
+}
+.chat-panel.open {
+    transform: translateX(0);
+}
+
+.chat-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px;
+    border-bottom: 1px solid #e6e6ef;
+}
+.chat-header h3 {
+    margin: 0;
+    font-size: 16px;
+}
+
+.chat-close {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 16px;
+    color: #666;
+}
+
+.chat-list {
+    flex: 1;
+    overflow: auto;
+    padding: 12px 14px;
+}
+
+.chat-item + .chat-item { margin-top: 10px; }
+.chat-user {
+    font-weight: 700;
+    font-size: 13px;
+    color: #333;
+}
+.chat-text {
+    font-size: 14px;
+    color: #222;
+}
+
+.chat-input {
+    display: flex;
+    gap: 8px;
+    padding: 10px 12px;
+    border-top: 1px solid #e6e6ef;
+}
+.chat-input input {
+    flex: 1;
+    border: 1px solid #e0e0ea;
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 14px;
+}
+.chat-input .send-btn {
+    border: none;
+    border-radius: 8px;
+    padding: 0 14px;
+    background: #6f42c1;
+    color: #fff;
+    cursor: pointer;
+}
+
+/* 다크 모드 */
+.dark-mode .chat-panel {
+    background: #1a1a26;
+    border-left: 1px solid rgba(255,255,255,0.08);
+    box-shadow: -10px 0 28px rgba(0,0,0,0.35);
+}
+
+.dark-mode .chat-header {
+    border-bottom-color: rgba(255,255,255,0.08);
+}
+
+.dark-mode .chat-close {
+    color: #bbb;
+}
+
+.dark-mode .chat-user {
+    color: #eaeaf2;
+}
+
+.dark-mode .chat-text {
+    color: #ddd;
+}
+
+.dark-mode .chat-input {
+    border-top-color: rgba(255,255,255,0.08);
+}
+.dark-mode .chat-input input {
+    background: #232333;
+    color: #eee;
+    border-color: #2f2f40;
+}
+.dark-mode .chat-input .send-btn {
+    background: #6a0dad;
+}

--- a/src/components/codecast/codecastlive/ChatPanel.jsx
+++ b/src/components/codecast/codecastlive/ChatPanel.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef, useState } from 'react';
+import './ChatPanel.css';
+import { FaTimes, FaPaperPlane } from 'react-icons/fa';
+
+export default function ChatPanel({ open, messages, onClose, onSend }) {
+    const [text, setText] = useState('');
+    const listRef = useRef(null);
+
+    useEffect(() => {
+        // 새 메시지 도착/열릴 때 하단으로 스크롤
+        listRef.current?.scrollTo({ top: listRef.current.scrollHeight, behavior: 'smooth' });
+    }, [messages, open]);
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        onSend?.(text);
+        setText('');
+    };
+
+    return (
+        <>
+            {/* 반투명 배경 (클릭 시 닫힘) */}
+            <div className={`chat-backdrop ${open ? 'show' : ''}`} onClick={onClose} />
+
+            {/* 패널 */}
+            <aside className={`chat-panel ${open ? 'open' : ''}`} aria-hidden={!open}>
+                <div className="chat-header">
+                    <h3>방 채팅</h3>
+                    <button className="chat-close" onClick={onClose} aria-label="채팅 닫기"><FaTimes /></button>
+                </div>
+
+                <div className="chat-list" ref={listRef}>
+                    {messages.map((m) => (
+                        <div key={m.id} className="chat-item">
+                            <div className="chat-user">{m.user}</div>
+                            <div className="chat-text">{m.text}</div>
+                        </div>
+                    ))}
+                </div>
+
+                <form className="chat-input" onSubmit={handleSubmit}>
+                    <input
+                        type="text"
+                        placeholder="메시지를 입력하세요…"
+                        value={text}
+                        onChange={(e) => setText(e.target.value)}
+                    />
+                    <button type="submit" className="send-btn" aria-label="전송">
+                        <FaPaperPlane />
+                    </button>
+                </form>
+            </aside>
+        </>
+    );
+}

--- a/src/components/codecast/codecastlive/CodeEditor.css
+++ b/src/components/codecast/codecastlive/CodeEditor.css
@@ -21,7 +21,7 @@
     gap: 12px;
 }
 
-/* ✅ 사용자 뱃지 (복원) */
+/* ✅ 사용자 뱃지 */
 .current-user-badge {
     background-color: #f2f2f4;
     color: #333;
@@ -33,6 +33,13 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
+}
+
+/* 오른쪽 버튼 묶음 */
+.toolbar-right {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
 }
 
 /* 실행 버튼 */
@@ -50,6 +57,26 @@
     transition: background-color 0.2s ease;
 }
 .run-button:hover { background-color: #8844dd; }
+
+/* 시각화 버튼 */
+.viz-button {
+    background-color: #f2f2f4;
+    color: #333;
+    border: 1px solid #e4e4ea;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color .2s ease;
+}
+.viz-button:hover {
+    background-color: #ece9f7;
+    border-color: #d7c7ff;
+    color: #4f2aa3;
+}
 
 /* Monaco 에디터가 부모 높이를 꽉 채우도록 */
 .code-editor > div, /* @monaco-editor/react 래퍼 */
@@ -70,4 +97,15 @@
     background-color: #222;
     color: #fff;
     border-color: #3a3a48;
+}
+
+.dark-mode .viz-button {
+    background-color: #2b2b34;
+    color: #eaeaf2;
+    border: 1px solid #3a3a48;
+}
+.dark-mode .viz-button:hover {
+    background-color: #34343f;
+    border-color: #6a0dad;
+    color: #c9a7ff;
 }

--- a/src/components/codecast/codecastlive/CodeEditor.jsx
+++ b/src/components/codecast/codecastlive/CodeEditor.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Editor from '@monaco-editor/react';
-import { FaPlay } from 'react-icons/fa';
+import { FaPlay, FaCrown, FaPenFancy, FaEye, FaChartBar } from 'react-icons/fa';
 import './CodeEditor.css';
 
 /**
@@ -19,16 +19,17 @@ export default function CodeEditor({ file, readOnly = false, onChange, currentUs
     const language = useMemo(() => file?.language || 'python', [file?.language]);
 
     const handleRun = () => alert('코드 실행 기능은 아직 미구현입니다.');
+    const handleVisualize = () => alert('코드 시각화 기능은 아직 미구현입니다.');
 
     const roleIcon = (role) => {
-        if (role === 'host') return '👑';
-        if (role === 'edit') return '✏️';
-        if (role === 'view') return '👁️';
+        if (role === 'host') return <FaCrown className="role-icon host" />;
+        if (role === 'edit') return <FaPenFancy className="role-icon edit" />;
+        if (role === 'view') return <FaEye className="role-icon view" />;
         return '';
     };
 
-    // const theme = document.body.classList.contains('dark-mode') ? 'vs-light' : 'vs-dark';
     const theme = isDark ? 'vs-dark' : 'vs-light';   // ✅ props 우선
+
     return (
         <section className="code-editor">
             <div className="editor-header">
@@ -39,9 +40,18 @@ export default function CodeEditor({ file, readOnly = false, onChange, currentUs
                     </div>
                 )}
 
-                <button className="run-button" onClick={handleRun}>
+                {/*<button className="run-button" onClick={handleRun}>
                     <FaPlay /> 실행
-                </button>
+                </button>*/}
+                {/* ✅ 오른쪽 툴바: 실행 + 시각화 */}
+                <div className="toolbar-right">
+                    <button className="run-button" onClick={handleRun}>
+                        <FaPlay/> 실행
+                    </button>
+                    <button className="viz-button" onClick={handleVisualize}>
+                        <FaChartBar/> 시각화
+                    </button>
+                </div>
             </div>
 
             {/* 필요 시 height=100%로 바꿔도 됩니다 (부모 컨테이너가 flex:1이면) */}

--- a/src/components/codecast/codecastlive/CodePreviewList.jsx
+++ b/src/components/codecast/codecastlive/CodePreviewList.jsx
@@ -12,22 +12,31 @@ export default function CodePreviewList({ participants, activeName, onSelect }) 
     return (
         <div className="preview-bar">
             <div className="preview-track">
-                {participants.map((p) => (
-                    <button
-                        key={p.name}
-                        className={`preview-card ${activeName === p.name ? 'active' : ''}`}
-                        onClick={() => onSelect(p.name)}
-                        title={`${p.name} 열기`}
-                    >
-                        <div className="preview-header">
-                            <RoleIcon role={p.role} />
-                            <span className="p-name">{p.name}</span>
-                        </div>
-                        <pre className="snippet">
-              {(p.code && p.code.trim()) ? p.code.slice(0, 120) : '파일 미선택 / 코드 없음'}
-            </pre>
-                    </button>
-                ))}
+                {participants.map((p) => {
+                    const hasFile = !!p.file; // 파일 선택 여부
+                    const content = p.file?.content ?? '';
+                    const hasContent = content.trim().length > 0;
+
+                    return (
+                        <button
+                            key={p.name}
+                            className={`preview-card ${activeName === p.name ? 'active' : ''}`}
+                            onClick={() => onSelect(p.name)}
+                            title={`${p.name} 열기`}
+                        >
+                            <div className="preview-header">
+                                <RoleIcon role={p.role} />
+                                <span className="p-name">{p.name}</span>
+                            </div>
+
+                            <pre className="snippet">
+                {hasFile
+                    ? (hasContent ? content.slice(0, 120) : '') // ✅ 새 파일(빈 내용) → 비워두기
+                    : '파일 미선택 / 코드 없음'}                  {/* ✅ 파일 없을 때만 플레이스홀더 */}
+              </pre>
+                        </button>
+                    );
+                })}
             </div>
         </div>
     );

--- a/src/components/codecast/codecastlive/CodecastHeader.css
+++ b/src/components/codecast/codecastlive/CodecastHeader.css
@@ -24,6 +24,36 @@
     color: #222;
 }
 
+/* 제목 수정 input */
+.title-input {
+    font-size: 20px;
+    font-weight: 700;
+    padding: 2px 6px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    outline: none;
+}
+
+.title-input:focus {
+    border-color: #6f42c1;
+    box-shadow: 0 0 0 2px rgba(111, 66, 193, 0.2);
+}
+
+/* 수정 버튼 */
+.edit-title-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: #666;
+    font-size: 14px;
+    margin-left: 6px;
+    transition: color 0.2s ease;
+}
+
+.edit-title-btn:hover {
+    color: #6f42c1;
+}
+
 .header-right {
     display: flex;
     align-items: center;

--- a/src/components/codecast/codecastlive/CodecastHeader.jsx
+++ b/src/components/codecast/codecastlive/CodecastHeader.jsx
@@ -1,28 +1,52 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { FaPen } from 'react-icons/fa';
 import './CodecastHeader.css';
 
-/**
- * Props
- * - roomTitle: string
- * - onLeave: () => void
- * - isFocusMode?: boolean          // 포커스 모드 여부
- * - onToggleFocus?: () => void     // 포커스 모드 토글
- */
 export default function CodecastHeader({
                                            roomTitle,
                                            onLeave,
                                            isFocusMode = false,
                                            onToggleFocus,
+                                           onTitleChange, // ✅ 제목 변경 핸들러 (부모에서 받음)
                                        }) {
+    const [isEditing, setIsEditing] = useState(false);
+    const [tempTitle, setTempTitle] = useState(roomTitle);
+
+    const handleSave = () => {
+        setIsEditing(false);
+        if (tempTitle.trim() && tempTitle !== roomTitle) {
+            onTitleChange?.(tempTitle);
+        }
+    };
+
     return (
         <header className="broadcastlive-header">
             <div className="header-left">
-                <h1 className="broadcast-title">{roomTitle}</h1>
-                {/* 파일명/언어/공유시작 제거 */}
+                {isEditing ? (
+                    <input
+                        type="text"
+                        value={tempTitle}
+                        onChange={(e) => setTempTitle(e.target.value)}
+                        onBlur={handleSave}
+                        onKeyDown={(e) => e.key === 'Enter' && handleSave()}
+                        autoFocus
+                        className="title-input"
+                    />
+                ) : (
+                    <>
+                        <h1 className="broadcast-title">{roomTitle}</h1>
+                        <button
+                            className="edit-title-btn"
+                            onClick={() => setIsEditing(true)}
+                            aria-label="제목 수정"
+                        >
+                            <FaPen />
+                        </button>
+                    </>
+                )}
             </div>
 
             <div className="header-right">
-                {/* 포커스 모드 버튼 */}
                 {onToggleFocus && (
                     <button
                         className={`focus-button ${isFocusMode ? 'active' : ''}`}

--- a/src/components/codecast/codecastlive/CodecastLive.jsx
+++ b/src/components/codecast/codecastlive/CodecastLive.jsx
@@ -55,7 +55,12 @@ const CodecastLive = ({ isDark }) => {
     const wrapperRef = useRef(null);         // ✅ 전체화면 타깃
     const [isFullscreen, setIsFullscreen] = useState(false); // ✅ 전체화면 상태
 
-    const room = useMemo(() => ({ id: 'sess-001', title: '정렬 알고리즘 라이브 코딩' }), []);
+    /*const room = useMemo(() => ({ id: 'sess-001', title: '정렬 알고리즘 라이브 코딩' }), []);*/
+    // 🔸 방 정보는 수정 가능해야 하므로 useState로
+    const [room, setRoom] = useState({
+        id: 'sess-001',
+        title: '정렬 알고리즘 라이브 코딩',
+    });
 
     // 🔸 단계: 공유 전("empty") ↔ 편집 중("editing")
     const [stage, setStage] = useState('empty');
@@ -147,13 +152,32 @@ const CodecastLive = ({ isDark }) => {
         <div ref={wrapperRef} className="broadcast-wrapper">
             <Header
                 roomTitle={room.title}
+                onTitleChange={(newTitle) => setRoom((prev) => ({ ...prev, title: newTitle }))}
                 onLeave={handleLeave}
                 isFocusMode={isFullscreen}        // 버튼 상태 표시
                 onToggleFocus={toggleFullscreen}  // 전체화면 토글
             />
 
             <div className="main-section">
-                <Sidebar participants={participants} currentUser={currentUser}/>
+                {/*<Sidebar participants={participants} currentUser={currentUser}/>*/}
+                <Sidebar
+                    participants={participants}
+                    currentUser={currentUser}
+                    onChangeRole={(name, nextRole) => {
+                        setParticipants(prev =>
+                            prev.map(p => (p.name === name ? { ...p, role: nextRole } : p))
+                        );
+                    }}
+                    onKick={(name) => {
+                        // 프리뷰/현재 사용자 등 동기화
+                        setParticipants(prev => prev.filter(p => p.name !== name));
+                        if (currentUser.name === name) {
+                            // 방출된 유저가 현재 선택 상황이면 첫 사용자로 스위칭
+                            const next = participants.find(p => p.name !== name);
+                            if (next) setCurrentUser(next);
+                        }
+                    }}
+                />
 
                 <div className="editor-area">
                     {stage === 'empty' && (
@@ -174,7 +198,7 @@ const CodecastLive = ({ isDark }) => {
                 </div>
             </div>
 
-            {/* ✅ 하단 프리뷰 리스트 재추가 */}
+            {/* ✅ 하단 프리뷰 리스트 */}
             <CodePreviewList
                 participants={participants}
                 activeName={currentUser.name}

--- a/src/components/codecast/codecastlive/CodecastLive.jsx
+++ b/src/components/codecast/codecastlive/CodecastLive.jsx
@@ -46,9 +46,9 @@ function mergeSort(arr) {
 ];
 
 const initialParticipants = [
-    { name: '김코딩', role: 'host', code: '' },
-    { name: '이알고', role: 'edit', code: '' },
-    { name: '박개발', role: 'view', code: '' },
+    { name: '김코딩', role: 'host', code: '', file: null, stage: 'empty' },
+    { name: '이알고', role: 'edit', code: '', file: null, stage: 'empty' },
+    { name: '박개발', role: 'view', code: '', file: null, stage: 'empty' },
 ];
 
 const CodecastLive = ({ isDark }) => {
@@ -88,24 +88,25 @@ const CodecastLive = ({ isDark }) => {
     const handleStartShare = () => setShowPicker(true);
 
     const handlePickFile = (picked) => {
-        setFile(picked);
-        setShowPicker(false);
-        setStage('editing');
-
-        // 현재 사용자 코드에 파일 내용 복사 (프리뷰/사이드바 반영)
-        setParticipants((prev) =>
-            prev.map((p) => (p.name === currentUser.name ? { ...p, code: picked.content } : p))
+        setParticipants(prev =>
+            prev.map(p =>
+                p.name === currentUser.name
+                    ? { ...p, file: picked, code: picked.content, stage: 'editing' }
+                    : p
+            )
         );
-        setCurrentUser((prev) => ({ ...prev, code: picked.content }));
+        setCurrentUser(prev => ({ ...prev, file: picked, code: picked.content, stage: 'editing' }));
+        setShowPicker(false);
     };
 
     const handleEditorChange = (nextText) => {
-        if (file) setFile({ ...file, content: nextText });
-
-        // 현재 사용자 코드도 업데이트해서 프리뷰에 반영
-        setCurrentUser((prev) => ({ ...prev, code: nextText }));
-        setParticipants((prev) =>
-            prev.map((p) => (p.name === currentUser.name ? { ...p, code: nextText } : p))
+        setCurrentUser(prev => ({ ...prev, code: nextText, file: { ...prev.file, content: nextText } }));
+        setParticipants(prev =>
+            prev.map(p =>
+                p.name === currentUser.name
+                    ? { ...p, code: nextText, file: { ...p.file, content: nextText } }
+                    : p
+            )
         );
     };
 
@@ -181,7 +182,7 @@ const CodecastLive = ({ isDark }) => {
                     currentUser={currentUser}
                     onChangeRole={(name, nextRole) => {
                         setParticipants(prev =>
-                            prev.map(p => (p.name === name ? { ...p, role: nextRole } : p))
+                            prev.map(p => (p.name === name ? {...p, role: nextRole} : p))
                         );
                     }}
                     onKick={(name) => {
@@ -197,16 +198,16 @@ const CodecastLive = ({ isDark }) => {
                 />
 
                 <div className="editor-area">
-                    {stage === 'empty' && (
+                    {currentUser.stage === 'empty' && (
                         <div className="empty-state">
                             <button className="plus-button" onClick={handleStartShare}>＋</button>
                             <p className="empty-help">파일을 선택하세요</p>
                         </div>
                     )}
 
-                    {stage === 'editing' && (
+                    {currentUser.stage === 'editing' && (
                         <CodeEditor
-                            file={file}
+                            file={currentUser.file}
                             onChange={handleEditorChange}
                             currentUser={currentUser}
                             isDark={isDark}

--- a/src/components/codecast/codecastlive/CodecastLive.jsx
+++ b/src/components/codecast/codecastlive/CodecastLive.jsx
@@ -6,7 +6,8 @@ import Header from './CodecastHeader';
 import Sidebar from './CodecastSidebar';
 import CodeEditor from './CodeEditor';
 import FilePickerModal from './FilePickerModal';
-import CodePreviewList from './CodePreviewList'; // ✅ 다시 추가
+import CodePreviewList from './CodePreviewList';
+import ChatPanel from './ChatPanel';
 
 // 더미 파일 목록
 const dummyFiles = [
@@ -77,6 +78,13 @@ const CodecastLive = ({ isDark }) => {
     // 🔸 현재 중앙에 띄울 사용자
     const [currentUser, setCurrentUser] = useState(initialParticipants[0]);
 
+    // 🔸 채팅창 열림 상태, 채팅 내용
+    const [isChatOpen, setIsChatOpen] = useState(false);
+    const [messages, setMessages] = useState([
+        { id: 1, user: '김코딩', text: '안녕하세요! 오늘은 버블 정렬부터 갈게요.' },
+        { id: 2, user: '이알고', text: '넵 준비됐습니다 🙌' },
+    ]);
+
     const handleStartShare = () => setShowPicker(true);
 
     const handlePickFile = (picked) => {
@@ -128,6 +136,14 @@ const CodecastLive = ({ isDark }) => {
         }
     };
 
+    const handleSendMessage = (text) => {
+        if (!text.trim()) return;
+        setMessages((prev) => [
+            ...prev,
+            { id: Date.now(), user: currentUser.name, text },
+        ]);
+    };
+
     // ✅ 전체화면 변경 이벤트로 상태 동기화
     useEffect(() => {
         const onChange = () => {
@@ -177,6 +193,7 @@ const CodecastLive = ({ isDark }) => {
                             if (next) setCurrentUser(next);
                         }
                     }}
+                    onOpenChat={() => setIsChatOpen(true)}            // ✅ 추가: 채팅 열기
                 />
 
                 <div className="editor-area">
@@ -217,6 +234,14 @@ const CodecastLive = ({ isDark }) => {
                         );
                     }
                 }}
+            />
+
+            {/* ✅ 채팅 패널 */}
+            <ChatPanel
+                open={isChatOpen}
+                messages={messages}
+                onClose={() => setIsChatOpen(false)}
+                onSend={handleSendMessage}
             />
 
             {showPicker && (

--- a/src/components/codecast/codecastlive/CodecastLive.jsx
+++ b/src/components/codecast/codecastlive/CodecastLive.jsx
@@ -81,8 +81,8 @@ const CodecastLive = ({ isDark }) => {
     // 🔸 채팅창 열림 상태, 채팅 내용
     const [isChatOpen, setIsChatOpen] = useState(false);
     const [messages, setMessages] = useState([
-        { id: 1, user: '김코딩', text: '안녕하세요! 오늘은 버블 정렬부터 갈게요.' },
-        { id: 2, user: '이알고', text: '넵 준비됐습니다 🙌' },
+        { id: 1, user: '김코딩', text: '안녕하세요!' },
+        { id: 2, user: '이알고', text: '🙌🙌' },
     ]);
 
     const handleStartShare = () => setShowPicker(true);

--- a/src/components/codecast/codecastlive/CodecastSidebar.css
+++ b/src/components/codecast/codecastlive/CodecastSidebar.css
@@ -8,6 +8,14 @@
     color: #222;
 }
 
+/* 타이틀 + 채팅 버튼 라인 */
+.sidebar-headline {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
 .codecast-sidebar-title {
     font-size: 16px;
     margin-bottom: 14px;
@@ -23,6 +31,21 @@
     font-size: 14px;
     font-weight: normal;
 }
+
+.chat-open-btn {
+    background: #f2f2f4;
+    color: #333;
+    border: 1px solid #e4e4ea;
+    padding: 6px 8px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background-color .15s ease, border-color .15s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.chat-open-btn:hover { background-color: #e9e9ef; }
 
 .participant-list {
     list-style: none;
@@ -164,6 +187,15 @@
 
 .dark-mode .codecast-sidebar-title { color: white; }
 .dark-mode .codecast-sidebar-title .count { color: #aaa; }
+
+.dark-mode .chat-open-btn {
+    background: #2b2b34;
+    color: #eaeaf2;
+    border: 1px solid #3a3a48;
+}
+.dark-mode .chat-open-btn:hover {
+    background: #34343f;
+}
 
 .dark-mode .participant-item:hover {
     background-color: rgba(255, 255, 255, 0.05);

--- a/src/components/codecast/codecastlive/CodecastSidebar.css
+++ b/src/components/codecast/codecastlive/CodecastSidebar.css
@@ -40,19 +40,48 @@
     margin-bottom: 6px;
     transition: background-color 0.2s ease;
     cursor: default;
+    position: relative; /* 팝오버 기준 */
 }
 .participant-item:hover {
     background-color: #ececf5;
 }
 
-.participant-icon {
+/* 프로필 아바타 */
+.avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+    background: #ddd;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.avatar.placeholder {
+    background: #bbb;
+}
+
+.default-user-icon {
+    font-size: 14px;
+    color: #fff;
+}
+
+/* 이름 */
+.participant-item .name {
+    flex: 1;
+    min-width: 0;
+}
+
+/* 역할 아이콘 */
+.role-icon {
     font-size: 15px;
 }
 
-/* 역할별 아이콘 색 (Light) */
-.participant-icon.host { color: #ffbf00; }
-.participant-icon.edit { color: #00a152; }
-.participant-icon.view { color: #999; }
+/* 역할별 색상 */
+.role-icon.host { color: #ffbf00; }
+.role-icon.edit { color: #00a152; }
+.role-icon.view { color: #999; }
 
 /* 현재 사용자 강조 (Light) */
 .participant-item.active-user {
@@ -60,6 +89,70 @@
     font-weight: 600;
     border-left: 3px solid #6a0dad;
 }
+
+/* 더보기 버튼 */
+.more-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 6px;
+    color: #666;
+    transition: background-color .12s ease, color .12s ease;
+}
+.more-btn:hover { background-color: rgba(0,0,0,0.05); }
+.dark-mode .more-btn:hover { background-color: rgba(255,255,255,0.08); }
+.dark-mode .more-btn { color: #bbb; }
+
+/* 팝오버 메뉴 */
+.more-menu {
+    position: absolute;
+    top: 36px;
+    right: 6px;
+    min-width: 160px;
+    background: #fff;
+    border: 1px solid #e6e6ef;
+    border-radius: 10px;
+    box-shadow: 0 10px 24px rgba(0,0,0,0.12);
+    padding: 8px;
+    z-index: 10;
+}
+
+.menu-group { display: flex; flex-direction: column; gap: 4px; }
+
+.menu-label {
+    font-size: 12px;
+    color: #888;
+    padding: 4px 6px 6px;
+}
+
+.menu-item {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 10px;
+    cursor: pointer;
+    color: #222;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.menu-item:hover { background: #f4f3fb; }
+.menu-item:disabled {
+    opacity: .55;
+    cursor: default;
+}
+.menu-item.danger {
+    color: #c62828;
+}
+.menu-divider {
+    height: 1px;
+    background: #eee;
+    margin: 6px 0;
+}
+.check { font-size: 12px; color: #6f42c1; }
 
 /* ========== Dark Mode Overrides ========== */
 
@@ -81,7 +174,27 @@
     border-left: 3px solid #6a0dad;
 }
 
+.dark-mode .avatar.placeholder {
+    background: #555;
+}
+
+.dark-mode .default-user-icon {
+    color: #ccc;
+}
+
 /* 아이콘 색상 (Dark) */
-.dark-mode .participant-icon.host { color: gold; }
-.dark-mode .participant-icon.edit { color: #00c853; }
-.dark-mode .participant-icon.view { color: #888; }
+.dark-mode .role-icon.host { color: gold; }
+.dark-mode .role-icon.edit { color: #00c853; }
+.dark-mode .role-icon.view { color: #888; }
+
+/* 다크 모드 팝오버 */
+.dark-mode .more-menu {
+    background: #1a1a26;
+    border-color: rgba(255,255,255,0.08);
+    box-shadow: 0 12px 28px rgba(0,0,0,0.35);
+}
+.dark-mode .menu-item { color: #eee; }
+.dark-mode .menu-item:hover { background: #232333; }
+.dark-mode .menu-label { color: #aaa; }
+.dark-mode .menu-divider { background: #2a2a36; }
+.dark-mode .menu-item.danger { color: #ff6b6b; }

--- a/src/components/codecast/codecastlive/CodecastSidebar.jsx
+++ b/src/components/codecast/codecastlive/CodecastSidebar.jsx
@@ -1,31 +1,127 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './CodecastSidebar.css';
-import { FaCrown, FaPenFancy, FaEye } from 'react-icons/fa';
+import { FaCrown, FaPenFancy, FaEye, FaUser, FaEllipsisV, FaCheck } from 'react-icons/fa';
 
-const IconByRole = ({ role }) => {
-    if (role === 'host') return <FaCrown className="participant-icon host" />;
-    if (role === 'edit') return <FaPenFancy className="participant-icon edit" />;
-    return <FaEye className="participant-icon view" />;
+const RoleIcon = ({ role }) => {
+    if (role === 'host') return <FaCrown className="role-icon host" />;
+    if (role === 'edit') return <FaPenFancy className="role-icon edit" />;
+    return <FaEye className="role-icon view" />;
 };
 
-export default function CodecastSidebar({ participants, currentUser }) {
+function useClickOutside(onClose) {
+    const ref = useRef(null);
+    useEffect(() => {
+        const handler = (e) => {
+            if (!ref.current) return;
+            if (!ref.current.contains(e.target)) onClose?.();
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [onClose]);
+    return ref;
+}
+
+/**
+ * Props
+ * - participants: {name, role, avatar?}[]
+ * - currentUser: {name, role}
+ * - onChangeRole?: (name, nextRole) => void
+ * - onKick?: (name) => void
+ */
+export default function CodecastSidebar({
+                                            participants,
+                                            currentUser,
+                                            onChangeRole,
+                                            onKick,
+                                        }) {
+    const [menuFor, setMenuFor] = useState(null); // 메뉴가 열린 사용자명
+
+    const closeMenu = () => setMenuFor(null);
+    const menuRef = useClickOutside(closeMenu);
+
     return (
         <aside className="codecast-sidebar">
             <h2 className="codecast-sidebar-title">
                 참여자 <span className="count">({participants.length})</span>
             </h2>
+
             <ul className="participant-list">
-                {participants.map((p) => (
-                    <li
-                        key={p.name}
-                        className={`participant-item ${
-                            p.name === currentUser.name ? 'active-user' : ''
-                        }`}
-                    >
-                        <IconByRole role={p.role} />
-                        <span className="name">{p.name}</span>
-                    </li>
-                ))}
+                {participants.map((p) => {
+                    const isActive = p.name === currentUser.name;
+                    const isMenuOpen = menuFor === p.name;
+
+                    return (
+                        <li
+                            key={p.name}
+                            className={`participant-item ${isActive ? 'active-user' : ''}`}
+                        >
+                            {/* 프로필 이미지 or 회색 원 */}
+                            {p.avatar ? (
+                                <img src={p.avatar} alt={p.name} className="avatar" />
+                            ) : (
+                                <div className="avatar placeholder">
+                                    <FaUser className="default-user-icon" />
+                                </div>
+                            )}
+
+                            {/* 이름 */}
+                            <span className="name">{p.name}</span>
+
+                            {/* 권한 아이콘 */}
+                            <RoleIcon role={p.role} />
+
+                            {/* 더보기 버튼 */}
+                            <button
+                                className="more-btn"
+                                aria-label={`${p.name} 더보기`}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    setMenuFor(isMenuOpen ? null : p.name);
+                                }}
+                            >
+                                <FaEllipsisV />
+                            </button>
+
+                            {/* 팝오버 메뉴 */}
+                            {isMenuOpen && (
+                                <div className="more-menu" ref={menuRef} onClick={(e) => e.stopPropagation()}>
+                                    <div className="menu-group">
+                                        <div className="menu-label">권한 설정</div>
+                                        {['host', 'edit', 'view'].map((role) => (
+                                            <button
+                                                key={role}
+                                                className="menu-item"
+                                                onClick={() => {
+                                                    onChangeRole && onChangeRole(p.name, role);
+                                                    closeMenu();
+                                                }}
+                                                disabled={p.role === role}
+                                                title={p.role === role ? '현재 권한' : '권한 변경'}
+                                            >
+                                                {p.role === role && <FaCheck className="check" />}
+                                                {role === 'host' ? '모든 권한(Host)' : role === 'edit' ? '편집(Editing)' : '보기(Read Only)'}
+                                            </button>
+                                        ))}
+                                    </div>
+
+                                    <div className="menu-divider" />
+
+                                    <button
+                                        className="menu-item danger"
+                                        onClick={() => {
+                                            onKick && onKick(p.name);
+                                            closeMenu();
+                                        }}
+                                        disabled={p.name === currentUser.name && p.role === 'host'} // 예: 자기 자신(방장) 강퇴 방지
+                                        title={p.name === currentUser.name && p.role === 'host' ? '방장은 강퇴 불가' : '강퇴하기'}
+                                    >
+                                        강퇴하기
+                                    </button>
+                                </div>
+                            )}
+                        </li>
+                    );
+                })}
             </ul>
         </aside>
     );

--- a/src/components/codecast/codecastlive/CodecastSidebar.jsx
+++ b/src/components/codecast/codecastlive/CodecastSidebar.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './CodecastSidebar.css';
-import { FaCrown, FaPenFancy, FaEye, FaUser, FaEllipsisV, FaCheck } from 'react-icons/fa';
+import { FaCrown, FaPenFancy, FaEye, FaUser, FaEllipsisV, FaCheck, FaComments } from 'react-icons/fa';
 
 const RoleIcon = ({ role }) => {
     if (role === 'host') return <FaCrown className="role-icon host" />;
@@ -33,6 +33,7 @@ export default function CodecastSidebar({
                                             currentUser,
                                             onChangeRole,
                                             onKick,
+                                            onOpenChat,
                                         }) {
     const [menuFor, setMenuFor] = useState(null); // 메뉴가 열린 사용자명
 
@@ -41,9 +42,22 @@ export default function CodecastSidebar({
 
     return (
         <aside className="codecast-sidebar">
-            <h2 className="codecast-sidebar-title">
+            {/*<h2 className="codecast-sidebar-title">
                 참여자 <span className="count">({participants.length})</span>
-            </h2>
+            </h2>*/}
+            <div className="sidebar-headline">         {/* ✅ 타이틀 라인 구조 변경 */}
+                <h2 className="codecast-sidebar-title">
+                    참여자 <span className="count">({participants.length})</span>
+                </h2>
+                <button
+                    className="chat-open-btn"
+                    onClick={onOpenChat}
+                    aria-label="채팅 열기"
+                    title="채팅 열기"
+                >
+                    <FaComments/>
+                </button>
+            </div>
 
             <ul className="participant-list">
                 {participants.map((p) => {
@@ -57,10 +71,10 @@ export default function CodecastSidebar({
                         >
                             {/* 프로필 이미지 or 회색 원 */}
                             {p.avatar ? (
-                                <img src={p.avatar} alt={p.name} className="avatar" />
+                                <img src={p.avatar} alt={p.name} className="avatar"/>
                             ) : (
                                 <div className="avatar placeholder">
-                                    <FaUser className="default-user-icon" />
+                                    <FaUser className="default-user-icon"/>
                                 </div>
                             )}
 
@@ -68,7 +82,7 @@ export default function CodecastSidebar({
                             <span className="name">{p.name}</span>
 
                             {/* 권한 아이콘 */}
-                            <RoleIcon role={p.role} />
+                            <RoleIcon role={p.role}/>
 
                             {/* 더보기 버튼 */}
                             <button
@@ -79,7 +93,7 @@ export default function CodecastSidebar({
                                     setMenuFor(isMenuOpen ? null : p.name);
                                 }}
                             >
-                                <FaEllipsisV />
+                                <FaEllipsisV/>
                             </button>
 
                             {/* 팝오버 메뉴 */}
@@ -98,13 +112,13 @@ export default function CodecastSidebar({
                                                 disabled={p.role === role}
                                                 title={p.role === role ? '현재 권한' : '권한 변경'}
                                             >
-                                                {p.role === role && <FaCheck className="check" />}
+                                                {p.role === role && <FaCheck className="check"/>}
                                                 {role === 'host' ? '모든 권한(Host)' : role === 'edit' ? '편집(Editing)' : '보기(Read Only)'}
                                             </button>
                                         ))}
                                     </div>
 
-                                    <div className="menu-divider" />
+                                    <div className="menu-divider"/>
 
                                     <button
                                         className="menu-item danger"

--- a/src/components/codecast/codecastlive/FilePickerModal.css
+++ b/src/components/codecast/codecastlive/FilePickerModal.css
@@ -51,6 +51,15 @@
     background: #eef0fb;
 }
 
+.fpm-item.new-file {
+    background: #efeaff;
+    border: 1px dashed #c9b6ff;
+}
+.fpm-item.new-file:hover {
+    background: #e7e0ff;
+    border-color: #bfa9ff;
+}
+
 .fpm-name {
     font-weight: 600;
     color: #333;
@@ -72,6 +81,84 @@
 }
 .fpm-close:hover { filter: brightness(1.03); }
 
+/* 새 파일 작성 UI */
+.fpm-newfile {
+    margin-top: 8px;
+    background: #f8f8ff;
+    border: 1px solid #ece9ff;
+    border-radius: 12px;
+    padding: 12px;
+}
+
+.fpm-row {
+    display: flex;
+    gap: 8px;
+}
+
+.fpm-input, .fpm-select {
+    padding: 10px 12px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    font-size: 14px;
+    color: #222;
+    background: #fff;
+}
+
+.fpm-input {
+    flex: 1;
+}
+
+.fpm-select {
+    width: 180px;
+}
+
+.fpm-hint {
+    margin-top: 8px;
+    font-size: 13px;
+    color: #666;
+}
+
+.fpm-preview {
+    color: #4f2aa3;
+}
+
+.fpm-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.fpm-primary,
+.fpm-secondary {
+    border: none;
+    border-radius: 10px;
+    padding: 10px 14px;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.fpm-primary {
+    background: #6a0dad;
+    color: #fff;
+}
+.fpm-primary:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+.fpm-primary:hover:not(:disabled) {
+    background: #7d2ae8;
+}
+
+.fpm-secondary {
+    background: #f2f2f7;
+    color: #333;
+    border: 1px solid #e4e4ea;
+}
+.fpm-secondary:hover {
+    background: #e9e9ef;
+}
+
 /* ========== Dark Mode Overrides ========== */
 
 .dark-mode .fpm-modal {
@@ -92,6 +179,15 @@
     background: #1f1f2c;
 }
 
+.dark-mode .fpm-item.new-file {
+    background: #201a33;
+    border-color: rgba(128,90,213,0.35);
+}
+.dark-mode .fpm-item.new-file:hover {
+    background: #251e3d;
+    border-color: rgba(128,90,213,0.6);
+}
+
 .dark-mode .fpm-name { color: #eee; }
 .dark-mode .fpm-lang { color: #bdbdbd; }
 
@@ -101,3 +197,23 @@
     border: none;
 }
 .dark-mode .fpm-close:hover { filter: brightness(1.05); }
+
+.dark-mode .fpm-newfile {
+    background: #1a1a26;
+    border-color: rgba(255,255,255,0.08);
+}
+.dark-mode .fpm-input,
+.dark-mode .fpm-select {
+    background: #232333;
+    color: #eee;
+    border-color: #2f2f40;
+}
+.dark-mode .fpm-hint { color: #c8c1d9; }
+.dark-mode .fpm-preview { color: #c9a7ff; }
+.dark-mode .fpm-secondary {
+    background: #2b2b34;
+    color: #eaeaf2;
+    border: 1px solid #3a3a48;
+}
+.dark-mode .fpm-secondary:hover { background: #34343f; }
+.dark-mode .fpm-primary { background: #6a0dad; }

--- a/src/components/codecast/codecastlive/FilePickerModal.jsx
+++ b/src/components/codecast/codecastlive/FilePickerModal.jsx
@@ -1,20 +1,118 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './FilePickerModal.css';
 
 export default function FilePickerModal({ files, onSelect, onClose }) {
+    const [isNewFile, setIsNewFile] = useState(false);
+    const [title, setTitle] = useState('');
+    const [language, setLanguage] = useState('python');
+
+    // 언어 → 확장자 매핑
+    const extensions = {
+        python: 'py',
+        java: 'java',
+        c: 'c',
+        'c++': 'cpp',
+        javascript: 'js',
+    };
+
+    const ensureExtension = (baseName, lang) => {
+        const ext = extensions[lang] || '';
+        const dotExt = `.${ext}`;
+        // 사용자가 이미 같은 확장자를 쓴 경우 중복 방지
+        if (baseName.toLowerCase().endsWith(dotExt)) return baseName;
+        // 사용자가 다른 확장자를 쓴 경우는 그대로 두고 뒤에 선택한 확장자를 붙임
+        return `${baseName}${dotExt}`;
+    };
+
+    const handleCreate = () => {
+        const raw = title.trim();
+        if (!raw) return;
+        const filename = ensureExtension(raw, language);
+        onSelect({
+            id: `new-${Date.now()}`,
+            name: filename,
+            language,
+            content: '',
+        });
+    };
+
     return (
         <div className="fpm-backdrop" onClick={onClose}>
             <div className="fpm-modal" onClick={(e) => e.stopPropagation()}>
                 <h3>공유할 파일 선택</h3>
-                <ul className="fpm-list">
-                    {files.map(f => (
-                        <li key={f.id} className="fpm-item" onClick={() => onSelect(f)}>
-                            <span className="fpm-name">{f.name}</span>
-                            <span className="fpm-lang">{f.language}</span>
-                        </li>
-                    ))}
-                </ul>
-                <button className="fpm-close" onClick={onClose}>닫기</button>
+
+                {!isNewFile ? (
+                    <>
+                        <ul className="fpm-list">
+                            <li
+                                className="fpm-item new-file"
+                                onClick={() => setIsNewFile(true)}
+                                title="새 파일 작성하기"
+                            >
+                                <span className="fpm-name">＋ 새 파일 작성하기</span>
+                                <span className="fpm-lang">제목 & 언어 선택</span>
+                            </li>
+
+                            {files.map((f) => (
+                                <li
+                                    key={f.id}
+                                    className="fpm-item"
+                                    onClick={() => onSelect(f)}
+                                >
+                                    <span className="fpm-name">{f.name}</span>
+                                    <span className="fpm-lang">{f.language}</span>
+                                </li>
+                            ))}
+                        </ul>
+
+                        <button className="fpm-close" onClick={onClose}>닫기</button>
+                    </>
+                ) : (
+                    <>
+                        <div className="fpm-newfile">
+                            <div className="fpm-row">
+                                <input
+                                    className="fpm-input"
+                                    type="text"
+                                    placeholder="파일 제목을 입력하세요 (예: BubbleSort)"
+                                    value={title}
+                                    onChange={(e) => setTitle(e.target.value)}
+                                    onKeyDown={(e) => { if (e.key === 'Enter') handleCreate(); }}
+                                    autoFocus
+                                />
+                                <select
+                                    className="fpm-select"
+                                    value={language}
+                                    onChange={(e) => setLanguage(e.target.value)}
+                                >
+                                    <option value="python">Python (.py)</option>
+                                    <option value="java">Java (.java)</option>
+                                    <option value="c">C (.c)</option>
+                                    <option value="c++">C++ (.cpp)</option>
+                                    <option value="javascript">JavaScript (.js)</option>
+                                </select>
+                            </div>
+
+                            <div className="fpm-hint">
+                                최종 파일명 미리보기:&nbsp;
+                                <strong className="fpm-preview">
+                                    {title ? ensureExtension(title, language) : '(제목을 입력하세요)'}
+                                </strong>
+                            </div>
+
+                            <div className="fpm-actions">
+                                <button className="fpm-secondary" onClick={() => setIsNewFile(false)}>
+                                    ← 목록으로
+                                </button>
+                                <button className="fpm-primary" onClick={handleCreate} disabled={!title.trim()}>
+                                    생성
+                                </button>
+                            </div>
+                        </div>
+
+                        <button className="fpm-close" onClick={onClose}>닫기</button>
+                    </>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
## 변경 사항
### 헤더 (CodecastHeader)
- 방송 제목 수정 기능 추가 (제목 옆 수정 아이콘 → 인라인 편집 가능)

### 에디터 (CodeEditor)
- 실행 버튼 옆에 코드 시각화 버튼 추가 (현재 두 버튼 다 미구현 알림)

### 사이드바 (CodecastSidebar)
- 참여자 목록 → 프로필 이미지(없으면 기본 원) + 이름 + 역할 아이콘 순으로 표시
- 각 참여자 끝에 … 메뉴 추가 → 권한 변경 / 강퇴 가능
- 사이드바 상단에 채팅창 열기 버튼 아이콘 추가

### 파일 선택 모달 (FilePickerModal)
- 기존 파일 목록 위에 새 파일 작성하기 옵션 추가
- 새 파일 작성 → 제목 입력 + 언어 선택 (python/java/c/c++/javascript)
- 언어 선택 시 자동으로 파일 확장자 붙여 생성
- 새 파일 생성 시 프리뷰는 빈 상태로 표시되며, 코드 작성 시 즉시 반영

### 프리뷰 리스트 (CodePreviewList)
- 파일 미선택 시: "파일 미선택 / 코드 없음"
- 기존 파일 선택 시: 내용 일부(최대 120자) 표시
- 새 파일 선택 시: 빈 상태로 표시 → 코드 입력하면 실시간 반영

### 라이브 메인 페이지 (CodecastLive)
- 참여자별 파일/코드/단계(empty/editing) 상태 관리
- 하단 프리뷰 리스트에서 사용자 전환 시 코드 반영
- 사이드바에서 채팅 아이콘 클릭 시 채팅창 패널 오픈

## 기타
- 현재 모든 데이터는 더미 데이터 사용중
- 다크 모드 대응 스타일 보완
- 채팅 입력 테스트 가능