### PR TITLE
코드방송 사이드바 참여자 이름 표시

### DIFF
--- a/src/components/codecast/codecastlive/CodecastSidebar.css
+++ b/src/components/codecast/codecastlive/CodecastSidebar.css
@@ -120,7 +120,6 @@
 .participant-main .name {
     font-weight: 500;
     text-overflow: ellipsis;
-    overflow: hidden;
     white-space: nowrap;
 }
 

--- a/src/components/codecast/codecastlive/CodecastSidebar.jsx
+++ b/src/components/codecast/codecastlive/CodecastSidebar.jsx
@@ -123,8 +123,10 @@ export default function CodecastSidebar({
                             )}
 
                             <div className="participant-main">
-                                <span className="name">
-                                    {displayName}
+                                <span className="name" title={displayName}>
+                                    {displayName.length > 4
+                                        ? displayName.slice(0, 4) + '…'
+                                        : displayName}
                                     {isSelf && <span className="self-badge">나</span>}
                                 </span>
                                 <span className={`stage ${stage}`}>{stageLabel}</span>


### PR DESCRIPTION
## 🔧 주요 변경 내역
### 1. CodecastSidebar.css
- .participant-main .name 내부에 있는 overflow: hidden; 삭제

### 2. CodecastSidebar.jsx
- JSX 코드 안에서 문자열 길이 조절
- displayName을 렌더링하기 전에 4글자까지만 slice()로 잘라주고, 그 이상이면 … 처리
- title={displayName} 추가하여 이름 위에 마우스 오버 시 툴팁으로 전체 이름 확인 가능  